### PR TITLE
`enterSGBProject` Pauses NaniNovel

### DIFF
--- a/Runtime/Commands/EnterSGBProject.cs
+++ b/Runtime/Commands/EnterSGBProject.cs
@@ -11,9 +11,28 @@ public class EnterSGBProject : Command
     [RequiredParameter, Documentation("The name of the SGB project to enter.")]
     public StringParameter Name;
 
-    public override UniTask ExecuteAsync(AsyncToken asyncToken = default)
+    public override async UniTask ExecuteAsync(AsyncToken asyncToken = default)
     {
+        // Thanks to the NaniNovel docs for implementing this nearly verbatim
+        // (https://naninovel.com/guide/integration-options.html#switching-modes)
+
+        // 1. Disable Naninovel input.
+        var inputManager = Engine.GetService<IInputManager>();
+        inputManager.ProcessInput = false;
+
+        // 2. Stop script player.
+        var scriptPlayer = Engine.GetService<IScriptPlayer>();
+        scriptPlayer.Stop();
+
+        // 3. Reset state.
+        var stateManager = Engine.GetService<IStateManager>();
+        await stateManager.ResetStateAsync();
+
+        // 4. Kill the NaniNovel camera.
+        var naniCamera = Engine.GetService<ICameraManager>().Camera;
+        naniCamera.enabled = false;
+
+        // 5. Load SGB!
         SGBManager.LoadSmileGame(Name.Value);
-        return UniTask.CompletedTask;
     }
 }


### PR DESCRIPTION
This PR revises the `enterSGBProject` command so that it:
* Stops NaniNovel input
* Stops the NaniNovel script player
* Resets the NaniNovel state
* Stops the NaniNovel camera
...before loading SGB. This makes the SGB loading seem seamless!