### PR TITLE
Debug Naninovel return uses custon Naninovel config

### DIFF
--- a/Runtime/FrontendModeManager.cs
+++ b/Runtime/FrontendModeManager.cs
@@ -15,7 +15,18 @@ namespace BobboNet.SGB.IMod.Naninovel
         {
             IModOverlay.AddButtonAction("Return to Naninovel", async () =>
             {
-                await EnterNaninovel(Engine.GetService<IScriptManager>().StartGameScriptName);
+                // Load the IMod config, and get the set return script name
+                var config = Engine.GetConfiguration<SGBIModConfiguration>();
+                string returnScriptName = config.overlayReturnScriptName;
+
+                // If there IS no return script setup, default to the engine's starting script
+                if (string.IsNullOrWhiteSpace(returnScriptName))
+                {
+                    returnScriptName = Engine.GetService<IScriptManager>().StartGameScriptName;
+                }
+
+                // Load back into the desired return script in naninovel
+                await EnterNaninovel(returnScriptName);
             });
         }
 

--- a/Runtime/SGBIModConfiguration.cs
+++ b/Runtime/SGBIModConfiguration.cs
@@ -9,6 +9,6 @@ namespace BobboNet.SGB.IMod.Naninovel
         [Header("Debug")]
         [Tooltip("The name of the script to return to when selecting the 'Return to Naninovel' option in the IMod Overlay. "
                 + "If empty, then this will default to the project's starting script.")]
-        public string debugOverlayReturnScriptName = "";
+        public string overlayReturnScriptName = "";
     }
 }

--- a/Runtime/SGBIModConfiguration.cs
+++ b/Runtime/SGBIModConfiguration.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using Naninovel;
+
+namespace BobboNet.SGB.IMod.Naninovel
+{
+    [EditInProjectSettings]
+    public class SGBIModConfiguration : Configuration
+    {
+        [Header("Debug")]
+        [Tooltip("The name of the script to return to when selecting the 'Return to Naninovel' option in the IMod Overlay. "
+                + "If empty, then this will default to the project's starting script.")]
+        public string debugOverlayReturnScriptName = "";
+    }
+}

--- a/Runtime/SGBIModConfiguration.cs.meta
+++ b/Runtime/SGBIModConfiguration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eecc07e3f90d19a42b6472d558c423c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR creates a custom config object that allows the user to change what script is entered when the IModOverlay is used to return to a Naninovel script.