### PR TITLE
NaniReturnService: Loading into Naninovel from an SGB map

### DIFF
--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eeca46ec4ecc05c4ba1650e8fe0c5eb6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/SGBIModSettings.cs
+++ b/Editor/SGBIModSettings.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditorInternal;
+using UnityEngine;
+using BobboNet.SGB.IMod.Naninovel;
+using Naninovel;
+
+namespace BobboNet.Editor.SGB.IMod.Naninovel
+{
+    public class SGBIModSettings : ConfigurationSettings<SGBIModConfiguration>
+    {
+        private const float sceneNameWidth = 140;
+        private const float headerLeftMargin = 15;
+        private const float paddingWidth = 10;
+
+        private static readonly GUIContent nameContent = new GUIContent("Scene Name", "The name of the UNITY scene to hook into. When this scene is loaded, it will unload from SGB and into the desired Naniscript.");
+        private static readonly GUIContent valueContent = new GUIContent("Target Naniscript", "The Naniscript to load into once the given UNITY scene is loaded.");
+
+        private ReorderableList returnTargetsReorderableList;
+
+        //
+        //  Override Methods
+        //
+
+        protected override Dictionary<string, Action<SerializedProperty>> OverrideConfigurationDrawers()
+        {
+            var drawers = base.OverrideConfigurationDrawers();
+            drawers[nameof(SGBIModConfiguration.returnTargets)] = DrawReturnTargetsEditor;
+            return drawers;
+        }
+
+        //
+        //  Return Target Methods
+        //
+
+        private void DrawReturnTargetsEditor(SerializedProperty property)
+        {
+            // Write the label for this list
+            var label = EditorGUI.BeginProperty(Rect.zero, null, property);
+            EditorGUILayout.LabelField(label, EditorStyles.boldLabel);
+
+            // If necessary, initialize the list
+            if (returnTargetsReorderableList is null || returnTargetsReorderableList.serializedProperty.serializedObject != SerializedObject)
+            {
+                InitializeReturnTargetsList();
+            }
+
+            returnTargetsReorderableList.DoLayoutList();
+
+            EditorGUI.EndProperty();
+        }
+
+        private void InitializeReturnTargetsList()
+        {
+            // Create the reorderable list object representing the return target list
+            var serializedProperty = SerializedObject.FindProperty(nameof(SGBIModConfiguration.returnTargets));
+            returnTargetsReorderableList = new ReorderableList(SerializedObject, serializedProperty, true, true, true, true);
+
+            // Specify callbacks to draw the header and elements of the return target list
+            returnTargetsReorderableList.drawHeaderCallback = OnDrawReturnTargetListHeader;
+            returnTargetsReorderableList.drawElementCallback = OnDrawReturnTargetListElement;
+        }
+
+        private void OnDrawReturnTargetListHeader(Rect rect)
+        {
+            var propertyRect = new Rect(headerLeftMargin + rect.x, rect.y, sceneNameWidth, EditorGUIUtility.singleLineHeight);
+            EditorGUI.LabelField(propertyRect, nameContent);
+            propertyRect.x += propertyRect.width + paddingWidth;
+            propertyRect.width = rect.width - sceneNameWidth;
+            EditorGUI.LabelField(propertyRect, valueContent);
+        }
+
+        private void OnDrawReturnTargetListElement(Rect rect, int index, bool isActive, bool isFocused)
+        {
+            var sceneNameRect = new Rect(
+                rect.x,
+                rect.y + EditorGUIUtility.standardVerticalSpacing,
+                sceneNameWidth,
+                EditorGUIUtility.singleLineHeight
+            );
+
+            var returnScriptRect = new Rect(
+                rect.x + sceneNameRect.width + paddingWidth,
+                rect.y + EditorGUIUtility.standardVerticalSpacing,
+                rect.width - sceneNameWidth - paddingWidth,
+                EditorGUIUtility.singleLineHeight
+            );
+
+            var elementProperty = returnTargetsReorderableList.serializedProperty.GetArrayElementAtIndex(index);
+            var sceneNameProperty = elementProperty.FindPropertyRelative("sceneName");
+            var returnScriptProperty = elementProperty.FindPropertyRelative("returnScript");
+
+            EditorGUI.PropertyField(sceneNameRect, sceneNameProperty, GUIContent.none);
+            EditorGUI.PropertyField(returnScriptRect, returnScriptProperty, GUIContent.none);
+        }
+    }
+}

--- a/Editor/SGBIModSettings.cs.meta
+++ b/Editor/SGBIModSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c97ab282c7247747891535c6a2c6a04
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/net.bobbo.sgb.imod.naninovel.Editor.asmdef
+++ b/Editor/net.bobbo.sgb.imod.naninovel.Editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "BobboNet.Editor.SGB.IMod.Naninovel",
+    "references": [
+        "BobboNet.SGB.IMod.Naninovel",
+        "Elringus.Naninovel.Runtime",
+        "Elringus.Naninovel.Editor"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/net.bobbo.sgb.imod.naninovel.Editor.asmdef.meta
+++ b/Editor/net.bobbo.sgb.imod.naninovel.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ab7e3c4fbca089a4690a218546d86a15
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/NaniReturnService.cs
+++ b/Runtime/NaniReturnService.cs
@@ -6,6 +6,9 @@ using BobboNet.SGB.IMod;
 
 namespace BobboNet.SGB.IMod.Naninovel
 {
+    /// <summary>
+    /// This service triggers returning to Naninovel from some runtime action.
+    /// </summary>
     [InitializeAtRuntime]
     public class NaniReturnService : IEngineService
     {
@@ -45,6 +48,12 @@ namespace BobboNet.SGB.IMod.Naninovel
         //  Private Methods
         //
 
+        /// <summary>
+        /// When a Unity Scene is loaded, read from the SGBIMod config to find out if we should re-enter Naninovel.
+        /// This is meant to be called by the SceneManager.sceneLoaded event.
+        /// </summary>
+        /// <param name="scene">The scene that was just loaded</param>
+        /// <param name="mode">HOW the scene was just loaded</param>
         private async void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
             // Get the return targets from our config, and check to see if this scene maps to one
@@ -54,6 +63,7 @@ namespace BobboNet.SGB.IMod.Naninovel
             // If there's no target for this scene, EXIT EARLY.
             if (foundTarget == null) return;
 
+            // Use the return target to determine how we re-enter Naninovel.
             await FrontendModeManager.EnterNaninovel(foundTarget.returnScript);
         }
     }

--- a/Runtime/NaniReturnService.cs
+++ b/Runtime/NaniReturnService.cs
@@ -45,9 +45,16 @@ namespace BobboNet.SGB.IMod.Naninovel
         //  Private Methods
         //
 
-        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        private async void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            Debug.Log($"Caught scene: {scene.name}");
+            // Get the return targets from our config, and check to see if this scene maps to one
+            var returnTargets = Engine.GetConfiguration<SGBIModConfiguration>().returnTargets;
+            var foundTarget = returnTargets.Find(x => x.sceneName == scene.name);
+
+            // If there's no target for this scene, EXIT EARLY.
+            if (foundTarget == null) return;
+
+            await FrontendModeManager.EnterNaninovel(foundTarget.returnScript);
         }
     }
 }

--- a/Runtime/NaniReturnService.cs
+++ b/Runtime/NaniReturnService.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Naninovel;
+using BobboNet.SGB.IMod;
+
+namespace BobboNet.SGB.IMod.Naninovel
+{
+    [InitializeAtRuntime]
+    public class NaniReturnService : IEngineService
+    {
+        //
+        //  Constructors
+        //
+
+        public NaniReturnService()
+        {
+
+        }
+
+        //
+        //  Interface Methods
+        //
+
+        public UniTask InitializeServiceAsync()
+        {
+            // Initialize the service here.
+            SceneManager.sceneLoaded += OnSceneLoaded;
+
+            return UniTask.CompletedTask;
+        }
+
+        public void ResetService()
+        {
+            // Reset service state here.
+        }
+
+        public void DestroyService()
+        {
+            // Stop the service and release any used resources here.
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+        }
+
+        //
+        //  Private Methods
+        //
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            Debug.Log($"Caught scene: {scene.name}");
+        }
+    }
+}

--- a/Runtime/NaniReturnService.cs.meta
+++ b/Runtime/NaniReturnService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac32570d43bf00546954d31d27367043
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/NaniscriptReturnTarget.cs
+++ b/Runtime/NaniscriptReturnTarget.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using Naninovel;
+
+namespace BobboNet.SGB.IMod.Naninovel
+{
+    [System.Serializable]
+    public class NaniscriptReturnTarget
+    {
+        /// <summary>
+        /// The name of the scene to listen for. If this scene is loaded, then this target will try to return
+        /// to the Naniscript defined in `returnScript`.
+        /// </summary>
+        public string sceneName = "";
+
+        /// <summary>
+        /// The name of the Naniscript to load into once the desired scene is loaded.
+        /// </summary>
+        [ResourcePopup(ScriptsConfiguration.DefaultPathPrefix, ScriptsConfiguration.DefaultPathPrefix)]
+        public string returnScript = "";
+    }
+}

--- a/Runtime/NaniscriptReturnTarget.cs
+++ b/Runtime/NaniscriptReturnTarget.cs
@@ -3,6 +3,9 @@ using Naninovel;
 
 namespace BobboNet.SGB.IMod.Naninovel
 {
+    /// <summary>
+    /// The Naniscript target of some NaniReturnService action.
+    /// </summary>
     [System.Serializable]
     public class NaniscriptReturnTarget
     {

--- a/Runtime/NaniscriptReturnTarget.cs.meta
+++ b/Runtime/NaniscriptReturnTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6e477bf54aba2042b1cfc260bae0ab2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SGBIModConfiguration.cs
+++ b/Runtime/SGBIModConfiguration.cs
@@ -10,6 +10,7 @@ namespace BobboNet.SGB.IMod.Naninovel
         [Header("Debug")]
         [Tooltip("The name of the script to return to when selecting the 'Return to Naninovel' option in the IMod Overlay. "
                 + "If empty, then this will default to the project's starting script.")]
+        [ResourcePopup(ScriptsConfiguration.DefaultPathPrefix, ScriptsConfiguration.DefaultPathPrefix, ResourcePopupAttribute.EmptyValue)]
         public string overlayReturnScriptName = "";
 
         [Header("Naniscript Return Targets")]

--- a/Runtime/SGBIModConfiguration.cs
+++ b/Runtime/SGBIModConfiguration.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections.Generic;
 using Naninovel;
 
 namespace BobboNet.SGB.IMod.Naninovel
@@ -10,5 +11,8 @@ namespace BobboNet.SGB.IMod.Naninovel
         [Tooltip("The name of the script to return to when selecting the 'Return to Naninovel' option in the IMod Overlay. "
                 + "If empty, then this will default to the project's starting script.")]
         public string overlayReturnScriptName = "";
+
+        [Header("Naniscript Return Targets")]
+        public List<NaniscriptReturnTarget> returnTargets = new List<NaniscriptReturnTarget>();
     }
 }


### PR DESCRIPTION
This PR introduces a new Naninovel service that listens to Unity's onSceneLoaded event, and uses that to re-enter a specific Naniscript.

The intent is when you want to go from SGB to Naninovel, you have SGB load into a specifically named map. Then, the NaniReturnService can listen for this map name, and when that map scene is loaded, return to a specified naniscript.