### PR TITLE
Two-Way Volume Sync

### DIFF
--- a/Runtime/FrontendModeManager.cs
+++ b/Runtime/FrontendModeManager.cs
@@ -58,7 +58,7 @@ namespace BobboNet.SGB.IMod.Naninovel
             var audioListener = NaniAudioListenerResolver.Find();
             if (audioListener != null) audioListener.enabled = false;
 
-            // 6. Update SGB's audio state. This is necessary to keep volume levels sync'd
+            // 6. Update the audio sync state. This is necessary to keep volume levels sync'd
             var sgbAudioBridge = Engine.GetService<SGBAudioBridgeService>();
             sgbAudioBridge.SyncSGBAudioState();
 
@@ -86,7 +86,11 @@ namespace BobboNet.SGB.IMod.Naninovel
             var audioListener = NaniAudioListenerResolver.Find();
             if (audioListener != null) audioListener.enabled = true;
 
-            // 5. TODO - Unload smile game
+            // 5. Update the audio sync state. This is necessary to keep volume levels sync'd
+            var sgbAudioBridge = Engine.GetService<SGBAudioBridgeService>();
+            sgbAudioBridge.SyncSGBAudioState();
+
+            // 6. TODO - Unload smile game
             await SGBManager.UnloadSmileGameAsync();
         }
     }

--- a/Runtime/FrontendModeManager.cs
+++ b/Runtime/FrontendModeManager.cs
@@ -58,7 +58,11 @@ namespace BobboNet.SGB.IMod.Naninovel
             var audioListener = NaniAudioListenerResolver.Find();
             if (audioListener != null) audioListener.enabled = false;
 
-            // 6. Start SGB!
+            // 6. Update SGB's audio state. This is necessary to keep volume levels sync'd
+            var sgbAudioBridge = Engine.GetService<SGBAudioBridgeService>();
+            sgbAudioBridge.SyncSGBAudioState();
+
+            // 7. Start SGB!
             await SGBManager.LoadSmileGameAsync(smileGameName);
         }
 

--- a/Runtime/SGBAudioBridgeService.cs
+++ b/Runtime/SGBAudioBridgeService.cs
@@ -53,6 +53,30 @@ namespace BobboNet.SGB.IMod.Naninovel
         }
 
         //
+        //  Public Methods
+        //
+
+        /// <summary>
+        /// Applies the audio mixer's volume levels to SGB's audio settings.
+        /// This is necessary to perform when loading in to an SGB instance, because otherwise
+        /// it will not know about outside audio changes.
+        /// </summary>
+        public void SyncSGBAudioState()
+        {
+            // If we can find the volume handle for the SFX group, apply the current volume to SGB
+            if (audioManager.AudioMixer.GetFloat(mixerHandleVolumeSFX, out float sfxVolumeDb))
+            {
+                SGBAudioSettings.SetVolumeSFXDecibels(sfxVolumeDb);
+            }
+
+            // If we can find the volume handle for the BGM group, apply the current volume to SGB
+            if (audioManager.AudioMixer.GetFloat(mixerHandleVolumeBGM, out float bgmVolumeDb))
+            {
+                SGBAudioSettings.SetVolumeBGMDecibels(bgmVolumeDb);
+            }
+        }
+
+        //
         //  Private Methods
         //
 
@@ -69,6 +93,8 @@ namespace BobboNet.SGB.IMod.Naninovel
             {
                 SGBAudioSettings.SetMixerGroupBGM(groupBGM, mixerHandleVolumeBGM);
             }
+
+            SyncSGBAudioState();
         }
 
         private void DisconnectFromSGB()

--- a/Runtime/SGBAudioBridgeService.cs
+++ b/Runtime/SGBAudioBridgeService.cs
@@ -13,6 +13,12 @@ namespace BobboNet.SGB.IMod.Naninovel
     [InitializeAtRuntime]
     public class SGBAudioBridgeService : IEngineService
     {
+        private const string mixerGroupNameSFX = "SFX";
+        private const string mixerHandleVolumeSFX = "SFX Volume";
+
+        private const string mixerGroupNameBGM = "BGM";
+        private const string mixerHandleVolumeBGM = "BGM Volume";
+
         private IAudioManager audioManager; // Naninovel's audio manager
 
         //
@@ -53,28 +59,28 @@ namespace BobboNet.SGB.IMod.Naninovel
         private void ConnectToSGB()
         {
             // If we can find an SFX mixer group, apply it to SGB
-            if (TryGetMixerGroup(audioManager.AudioMixer, "SFX", out AudioMixerGroup groupSFX))
+            if (TryGetMixerGroup(audioManager.AudioMixer, mixerGroupNameSFX, out AudioMixerGroup groupSFX))
             {
-                SGBAudioSettings.SetMixerGroupSFX(groupSFX);
+                SGBAudioSettings.SetMixerGroupSFX(groupSFX, mixerHandleVolumeSFX);
             }
 
             // If we can find a BGM mixer group, apply it to SGB
-            if (TryGetMixerGroup(audioManager.AudioMixer, "BGM", out AudioMixerGroup groupBGM))
+            if (TryGetMixerGroup(audioManager.AudioMixer, mixerGroupNameBGM, out AudioMixerGroup groupBGM))
             {
-                SGBAudioSettings.SetMixerGroupBGM(groupBGM);
+                SGBAudioSettings.SetMixerGroupBGM(groupBGM, mixerHandleVolumeBGM);
             }
         }
 
         private void DisconnectFromSGB()
         {
             // If the mixer group assigned to SGB's SFX is Naninovel's SFX mixer group, unassign it.
-            if (TryGetMixerGroup(audioManager.AudioMixer, "SFX", out AudioMixerGroup groupSFX) && groupSFX == SGBAudioSettings.GetMixerGroupSFX())
+            if (TryGetMixerGroup(audioManager.AudioMixer, mixerGroupNameSFX, out AudioMixerGroup groupSFX) && groupSFX == SGBAudioSettings.GetMixerGroupSFX())
             {
                 SGBAudioSettings.SetMixerGroupSFX(null);
             }
 
             // If the mixer group assigned to SGB's BGM is Naninovel's BGM mixer group, unassign it.
-            if (TryGetMixerGroup(audioManager.AudioMixer, "BGM", out AudioMixerGroup groupBGM) && groupBGM == SGBAudioSettings.GetMixerGroupBGM())
+            if (TryGetMixerGroup(audioManager.AudioMixer, mixerGroupNameBGM, out AudioMixerGroup groupBGM) && groupBGM == SGBAudioSettings.GetMixerGroupBGM())
             {
                 SGBAudioSettings.SetMixerGroupBGM(null);
             }

--- a/Runtime/SGBAudioBridgeService.cs
+++ b/Runtime/SGBAudioBridgeService.cs
@@ -63,16 +63,18 @@ namespace BobboNet.SGB.IMod.Naninovel
         /// </summary>
         public void SyncSGBAudioState()
         {
-            // If we can find the volume handle for the SFX group, apply the current volume to SGB
+            // If we can find the volume handle for the SFX group, apply the current volume
             if (audioManager.AudioMixer.GetFloat(mixerHandleVolumeSFX, out float sfxVolumeDb))
             {
                 SGBAudioSettings.SetVolumeSFXDecibels(sfxVolumeDb);
+                audioManager.SfxVolume = VolumeUtils.DbToVolumeFloat(sfxVolumeDb);
             }
 
-            // If we can find the volume handle for the BGM group, apply the current volume to SGB
+            // If we can find the volume handle for the BGM group, apply the current volume
             if (audioManager.AudioMixer.GetFloat(mixerHandleVolumeBGM, out float bgmVolumeDb))
             {
                 SGBAudioSettings.SetVolumeBGMDecibels(bgmVolumeDb);
+                audioManager.BgmVolume = VolumeUtils.DbToVolumeFloat(bgmVolumeDb);
             }
         }
 


### PR DESCRIPTION
This PR updates the audio bridge service so that it properly syncs volume levels between SGB and Naninovel. Adjusting volume in SGB will adjust Naninovels levels, and vice-versa. It does this by using the dB level of each channel of Naninovel's mixer as shared states for volume.