### PR TITLE
SGB Saves in Naninovel State

### DIFF
--- a/Runtime/FrontendModeManager.cs
+++ b/Runtime/FrontendModeManager.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
-using UnityEngine;
 using Naninovel;
-using BobboNet.SGB.IMod;
+using System;
 
 namespace BobboNet.SGB.IMod.Naninovel
 {
@@ -48,7 +47,8 @@ namespace BobboNet.SGB.IMod.Naninovel
 
             // 3. Reset state if necessary
             var stateManager = Engine.GetService<IStateManager>();
-            await stateManager.ResetStateAsync();
+            var servicesToNotReset = new Type[] { typeof(IStateManager), typeof(SGBSaveBridgeService) };
+            await stateManager.ResetStateAsync(exclude: servicesToNotReset);
 
             // 4. Set NaniNovel camera inactive.
             var naniCamera = Engine.GetService<ICameraManager>().Camera;

--- a/Runtime/SGBSaveBridgeService.cs
+++ b/Runtime/SGBSaveBridgeService.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 using Naninovel;
 using BobboNet.SGB.IMod;
+using System.IO;
 
 namespace BobboNet.SGB.IMod.Naninovel
 {
@@ -11,7 +12,23 @@ namespace BobboNet.SGB.IMod.Naninovel
     [InitializeAtRuntime]
     public class SGBSaveBridgeService : IEngineService
     {
+        //
+        //  Classes
+        //
+
+        [System.Serializable]
+        private class SGBSaveState
+        {
+            public int saveIndex;
+            public string serializedState;
+        }
+
+        //
+        //  Variables
+        //
+
         private IStateManager stateManager; // Naninovel's game state manager
+        private SGBSaveState currentSaveState = null; // The last SGB save state
 
         //
         //  Constructors
@@ -29,37 +46,109 @@ namespace BobboNet.SGB.IMod.Naninovel
         public UniTask InitializeServiceAsync()
         {
             // Initialize the service here.
-            ConnectToSGB();
+
+            // Connect to Naninovel
+            stateManager.AddOnGameSerializeTask(OnNaninovelStateSerialize);
+            stateManager.AddOnGameDeserializeTask(OnNaninovelDeserializeState);
+
+            // Connect to SGB
+            SGBSaveManager.SaveDataOverrideFunc = OnSGBSave;
+            SGBSaveManager.LoadDataOverrideFunc = OnSGBLoad;
+
             return UniTask.CompletedTask;
         }
 
         public void ResetService()
         {
             // Reset service state here.
+            currentSaveState = null;
         }
 
         public void DestroyService()
         {
             // Stop the service and release any used resources here.
-            DisconnectFromSGB();
-        }
 
-        //
-        //  Public Methods
-        //
+            // Disconnect from Naninovel
+            stateManager.RemoveOnGameSerializeTask(OnNaninovelStateSerialize);
+            stateManager.RemoveOnGameDeserializeTask(OnNaninovelDeserializeState);
+
+            // Disconnect from SGB
+            SGBSaveManager.SaveDataOverrideFunc = null;
+            SGBSaveManager.LoadDataOverrideFunc = null;
+        }
 
         //
         //  Private Methods
         //
 
-        private void ConnectToSGB()
+        /// <summary>
+        /// A callback that's called when Naninovel serializes the current game state (for saving)
+        /// </summary>
+        /// <param name="stateMap">The object to serialize the current game state into.</param>
+        private void OnNaninovelStateSerialize(GameStateMap stateMap)
         {
+            if (currentSaveState == null) return;
 
+            stateMap.SetState(currentSaveState);
         }
 
-        private void DisconnectFromSGB()
+        /// <summary>
+        /// A callback that's called when Naninovel deserializes a game state (when loading)
+        /// </summary>
+        /// <param name="stateMap"></param>
+        /// <returns></returns>
+        private UniTask OnNaninovelDeserializeState(GameStateMap stateMap)
         {
+            // Try to load the SGB save
+            var foundSave = stateMap.GetState<SGBSaveState>();
+            if (foundSave == null) return UniTask.CompletedTask;
 
+            // ...and if there is one, cache it
+            currentSaveState = foundSave;
+            return UniTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// A callback that's called when SGB serializes it's game state, and wants to write it somewhere.
+        /// </summary>
+        /// <param name="saveIndex">Which SGB save-data is being saved</param>
+        /// <param name="dataToSave">The raw binary data to be saved.</param>
+        private void OnSGBSave(int saveIndex, Stream dataToSave)
+        {
+            SGBSaveState newSave = new SGBSaveState();
+            newSave.saveIndex = saveIndex;
+
+            // Rewind the data to the beginning & convert it to a string we can handle
+            using (var conversionBuffer = new MemoryStream())
+            {
+                dataToSave.Seek(0, SeekOrigin.Begin);
+                dataToSave.CopyTo(conversionBuffer);
+                newSave.serializedState = System.Convert.ToBase64String(conversionBuffer.ToArray());
+            }
+
+
+            // If all is well, update our cached state
+            currentSaveState = newSave;
+        }
+
+        /// <summary>
+        /// A callback that's called when SGB wants to deserialize it's game state, and needs to read it from somewhere.
+        /// </summary>
+        /// <param name="saveIndex">Which SGB save-data is being loaded</param>
+        /// <returns>A stream containing the loaded data</returns>
+        private Stream OnSGBLoad(int saveIndex)
+        {
+            // If we have no cached save states, EXIT
+            if (currentSaveState == null) return null;
+
+            // If our save index mismatches, EXIT
+            if (currentSaveState.saveIndex != saveIndex) return null;
+
+            // If we don't have serialized data, EXIT
+            if (string.IsNullOrEmpty(currentSaveState.serializedState)) return null;
+
+            // OTHERWISE - convert our base64 string into some data
+            return new MemoryStream(System.Convert.FromBase64String(currentSaveState.serializedState));
         }
     }
 }

--- a/Runtime/SGBSaveBridgeService.cs
+++ b/Runtime/SGBSaveBridgeService.cs
@@ -1,0 +1,65 @@
+using System.Threading.Tasks;
+using UnityEngine;
+using Naninovel;
+using BobboNet.SGB.IMod;
+
+namespace BobboNet.SGB.IMod.Naninovel
+{
+    /// <summary>
+    /// This service connects Naninovel's audio with SGB's audio using IMod.
+    /// </summary>
+    [InitializeAtRuntime]
+    public class SGBSaveBridgeService : IEngineService
+    {
+        private IStateManager stateManager; // Naninovel's game state manager
+
+        //
+        //  Constructors
+        //
+
+        public SGBSaveBridgeService(IStateManager stateManager)
+        {
+            this.stateManager = stateManager;
+        }
+
+        //
+        //  Interface Methods
+        //
+
+        public UniTask InitializeServiceAsync()
+        {
+            // Initialize the service here.
+            ConnectToSGB();
+            return UniTask.CompletedTask;
+        }
+
+        public void ResetService()
+        {
+            // Reset service state here.
+        }
+
+        public void DestroyService()
+        {
+            // Stop the service and release any used resources here.
+            DisconnectFromSGB();
+        }
+
+        //
+        //  Public Methods
+        //
+
+        //
+        //  Private Methods
+        //
+
+        private void ConnectToSGB()
+        {
+
+        }
+
+        private void DisconnectFromSGB()
+        {
+
+        }
+    }
+}

--- a/Runtime/SGBSaveBridgeService.cs.meta
+++ b/Runtime/SGBSaveBridgeService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34d26be937985f941971ef83aea18bfe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR implements a bridging service that automatically hooks into IMod to make SGB store & load it's save data in the current Naninovel state.

This means that SGB save files can be written and read from naninovel save files.

At the moment, it only supports storing one save file, but this is a pretty artificial implementation. Down the line we can support multiple, but for the purpose of Dome-King's usecase, we really only need one.