### PR TITLE
Auto SGB Save Button Disable

### DIFF
--- a/Runtime/SGBSaveBridgeService.cs
+++ b/Runtime/SGBSaveBridgeService.cs
@@ -53,6 +53,8 @@ namespace BobboNet.SGB.IMod.Naninovel
             SGBSaveManager.SaveDataOverrideFunc = OnSGBSave;
             SGBSaveManager.ReadSaveInfoOverrideFunc = OnSGBReadSaveInfo;
             SGBSaveManager.LoadDataOverrideFunc = OnSGBLoad;
+            SGBPauseMenuOptions.SaveButton.IsVisible = false;
+            SGBPauseMenuOptions.SaveButton.IsInteractable = false;
 
             return UniTask.CompletedTask;
         }
@@ -75,6 +77,8 @@ namespace BobboNet.SGB.IMod.Naninovel
             SGBSaveManager.SaveDataOverrideFunc = null;
             SGBSaveManager.ReadSaveInfoOverrideFunc = null;
             SGBSaveManager.LoadDataOverrideFunc = null;
+            SGBPauseMenuOptions.SaveButton.IsVisible = true;
+            SGBPauseMenuOptions.SaveButton.IsInteractable = true;
         }
 
         //


### PR DESCRIPTION
This PR hooks into IMod's new exposed pause menu options to automatically mark SGB's pause menu save button as not interactable and not visible.

This has been done to prevent save-file weirdness and softlocking when using the SGBSaveBridgeService.