### PR TITLE
NaniReturnService uses Pre-Load Operations

### DIFF
--- a/Runtime/Commands/EnterSGBProject.cs
+++ b/Runtime/Commands/EnterSGBProject.cs
@@ -36,8 +36,8 @@ public class EnterSGBProject : Command
         int saveIndex = Assigned(SaveIndex) ? SaveIndex.Value : 0;
 
         // Determine the map loading parameters, if any
-        BobboNet.SGB.IMod.SGBManager.EntryMapParameters mapLoadParams = null;
-        if (Assigned(MapName)) mapLoadParams = new SGBManager.EntryMapParameters
+        LoadSGBMapArgs mapLoadParams = null;
+        if (Assigned(MapName)) mapLoadParams = new LoadSGBMapArgs
         {
             MapName = MapName.Value,
             StartPosition = new Vector2Int(MapStartPositionX.Value, MapStartPositionY.Value),

--- a/Runtime/FrontendModeManager.cs
+++ b/Runtime/FrontendModeManager.cs
@@ -35,7 +35,7 @@ namespace BobboNet.SGB.IMod.Naninovel
 
         // Thanks to the NaniNovel docs for implementing this nearly verbatim
         // (https://naninovel.com/guide/integration-options.html#switching-modes)
-        public static async Task EnterSGBGame(string smileGameName, int saveFile = -1, IMod.SGBManager.EntryMapParameters mapLoadParams = null)
+        public static async Task EnterSGBGame(string smileGameName, int saveFile = -1, IMod.LoadSGBMapArgs mapLoadParams = null)
         {
             // 1. Set Naninovel input inactive.
             var inputManager = Engine.GetService<IInputManager>();


### PR DESCRIPTION
This PR revises the NaniReturnService to use SGB Map Pre-Load operations rather than relying on the Unity Scene Management callbacks to take action.

This is good because it makes the hand-off from SGB to Nani a little more stable, and a little quicker, as scenes that the return service is listening for do not need to be fully loaded first.