### PR TITLE
SGB Font Bridge

### DIFF
--- a/Runtime/SGBFontBridgeService.cs
+++ b/Runtime/SGBFontBridgeService.cs
@@ -1,0 +1,70 @@
+using UnityEngine;
+using Naninovel;
+
+namespace BobboNet.SGB.IMod.Naninovel
+{
+    /// <summary>
+    /// This service connects custom fonts with SGB IMod.
+    /// </summary>
+    [InitializeAtRuntime]
+    public class SGBFontBridgeService : IEngineService
+    {
+        private Font originalFont;
+
+        //
+        //  Constructors
+        //
+
+        public SGBFontBridgeService() { }
+
+        //
+        //  Interface Methods
+        //
+
+        public UniTask InitializeServiceAsync()
+        {
+            // Initialize the service here.
+            ConnectToSGB();
+            return UniTask.CompletedTask;
+        }
+
+        public void ResetService()
+        {
+            // Reset service state here.
+        }
+
+        public void DestroyService()
+        {
+            // Stop the service and release any used resources here.
+            DisconnectFromSGB();
+        }
+
+        //
+        //  Public Methods
+        //
+
+        //
+        //  Private Methods
+        //
+
+        private void ConnectToSGB()
+        {
+            var configIMod = Engine.GetConfiguration<SGBIModConfiguration>();
+
+            // Cache whatever font SGB is using
+            originalFont = SGBFontManager.CurrentFont;
+
+            // If we have a custom font to use, apply it to SGB
+            if (configIMod.customTextFont != null)
+            {
+                SGBFontManager.CurrentFont = configIMod.customTextFont;
+            }
+        }
+
+        private void DisconnectFromSGB()
+        {
+            // Re-apply the cache'd font from SGB
+            SGBFontManager.CurrentFont = originalFont;
+        }
+    }
+}

--- a/Runtime/SGBFontBridgeService.cs.meta
+++ b/Runtime/SGBFontBridgeService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fe7772a6d00367498672fd8e291b6bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SGBIModConfiguration.cs
+++ b/Runtime/SGBIModConfiguration.cs
@@ -28,6 +28,10 @@ namespace BobboNet.SGB.IMod.Naninovel
         [ResourcePopup(ScriptsConfiguration.DefaultPathPrefix, ScriptsConfiguration.DefaultPathPrefix, ResourcePopupAttribute.EmptyValue)]
         public string overlayReturnScriptName = "";
 
+        [Header("SGB Fonts")]
+        [Tooltip("A custom font to use when running SGB.")]
+        public Font customTextFont = null;
+
         [Header("SGB Save Files")]
         [Tooltip("How many save slots SGB will display at max.")]
         public int maxSGBSaveSlots = 40;


### PR DESCRIPTION
This PR implements the SGBFontBridgeService, which allows you to specify a custom font for SGB in the naninovel config. This service will then apply / unapply it when naninovel is constructed / destructed.